### PR TITLE
do not require fillModeNonSolid

### DIFF
--- a/code/renderer_vulkan/RB_DrawTris.c
+++ b/code/renderer_vulkan/RB_DrawTris.c
@@ -10,6 +10,16 @@ Draws triangle outlines for debugging
 */
 void RB_DrawTris (shaderCommands_t * pInput)
 {
+	if (vk.features.fillModeNonSolid == VK_FALSE) {
+		static qboolean printed = qfalse;
+		if (!printed) {
+			ri.Printf(PRINT_WARNING, "RB_ShowTris: fillModeNonSolid not supported.\n");
+			printed = qtrue;
+		}
+		return;
+	}
+
+
 	updateCurDescriptor( tr.whiteImage->descriptor_set, 0);
 
 	// VULKAN

--- a/code/renderer_vulkan/vk_instance.c
+++ b/code/renderer_vulkan/vk_instance.c
@@ -605,14 +605,10 @@ static void vk_createLogicalDevice(void)
     // has specific feature requirements it should check supported
     // features based on this query.
 
-	VkPhysicalDeviceFeatures features;
-	qvkGetPhysicalDeviceFeatures(vk.physical_device, &features);
-	if (features.shaderClipDistance == VK_FALSE)
+	qvkGetPhysicalDeviceFeatures(vk.physical_device, &vk.features);
+	if (vk.features.shaderClipDistance == VK_FALSE)
 		ri.Error(ERR_FATAL,
             "vk_create_device: shaderClipDistance feature is not supported");
-	if (features.fillModeNonSolid == VK_FALSE)
-	    ri.Error(ERR_FATAL,
-            "vk_create_device: fillModeNonSolid feature is not supported");
 
 
     VkDeviceCreateInfo device_desc;
@@ -625,7 +621,7 @@ static void vk_createLogicalDevice(void)
     device_desc.ppEnabledLayerNames = NULL;
     device_desc.enabledExtensionCount = 1;
     device_desc.ppEnabledExtensionNames = device_extensions;
-    device_desc.pEnabledFeatures = &features;
+    device_desc.pEnabledFeatures = &vk.features;
     
 
     // After selecting a physical device to use we need to set up a

--- a/code/renderer_vulkan/vk_instance.h
+++ b/code/renderer_vulkan/vk_instance.h
@@ -136,6 +136,7 @@ const char * cvtResToStr(VkResult result);
 struct Vk_Instance {
 	VkInstance instance ;
 	VkPhysicalDevice physical_device;
+	VkPhysicalDeviceFeatures features;
 
     // Native platform surface or window objects are abstracted by surface objects,
     // which are represented by VkSurfaceKHR handles. The VK_KHR_surface extension


### PR DESCRIPTION
This feature isn't always available, and is only used while debugging. So let's not make it a hard requirement.

Closes: #22 