### PR TITLE
make sure viewport is initialized

### DIFF
--- a/code/renderer_vulkan/tr_backend.c
+++ b/code/renderer_vulkan/tr_backend.c
@@ -1,6 +1,7 @@
 #include "ref_import.h"
 #include "tr_backend.h"
 #include "R_PrintMat.h"
+#include "glConfig.h"
 backEndState_t backEnd;
 
 
@@ -9,6 +10,11 @@ void R_ClearBackendState(void)
     ri.Printf(PRINT_ALL, " backend state cleared. \n");
 	// clear all our internal state
 	memset( &backEnd, 0, sizeof( backEnd ) );
+
+    int width, height;
+    R_GetWinResolution(&width, &height);
+    backEnd.viewParms.viewportWidth = width;
+    backEnd.viewParms.viewportHeight = height;
 }
 
 

--- a/code/renderer_vulkan/vk_init.c
+++ b/code/renderer_vulkan/vk_init.c
@@ -7,7 +7,7 @@
 #include "vk_shade_geometry.h"
 #include "vk_shaders.h"
 #include "glConfig.h"
-
+#include "tr_backend.h"
 
 // vk_init have nothing to do with tr_init
 // vk_instance should be small
@@ -40,6 +40,9 @@ void vk_initialize(void)
     int height;
 
     R_GetWinResolution(&width, &height);
+
+    backEnd.viewParms.viewportWidth = width;
+    backEnd.viewParms.viewportHeight = height;
 
     // Depth attachment image.
     vk_createDepthAttachment(width, height);

--- a/code/renderer_vulkan/vk_shade_geometry.c
+++ b/code/renderer_vulkan/vk_shade_geometry.c
@@ -165,6 +165,8 @@ VkRect2D get_scissor_rect(void)
 	}
 	else
 	{
+		assert(backEnd.viewParms.viewportWidth > 0);
+		assert(backEnd.viewParms.viewportHeight > 0);
 		r.offset.x = backEnd.viewParms.viewportX;
         r.offset.y = backEnd.viewParms.viewportY;
         r.extent.width = backEnd.viewParms.viewportWidth;


### PR DESCRIPTION
It's illegal to pass a render-area with a width or height of zero to Vulkan. But we initialize the viewport to zero, which prevents us from rendering the initial frames.

So let's make sure we initialize the viewport to the full window size. This matches OpenGL's behavior.

This fixes validation errors and missing rendering on start-up.