### PR TITLE
fixed typo win R_FindShader

### DIFF
--- a/code/renderer_vulkan/R_FindShader.c
+++ b/code/renderer_vulkan/R_FindShader.c
@@ -420,7 +420,7 @@ static void Shader_DoSimpleCheck(char* name, char* p)
         if(0 == *token)
             break;
         char shaderName[64]={0};
-        strlcpy(shaderName, token, sizeof(shaderName));
+        strncpy(shaderName, token, sizeof(shaderName));
 
         int shaderLine = R_GetCurrentParseLine();
 


### PR DESCRIPTION
"strncpy" was typed as "strlcpy" which caused it to fail to compile.
![Screenshot_20241210_091030](https://github.com/user-attachments/assets/8d6c34fc-5974-4e70-bdb1-99252c4190ce)
