### PR TITLE
Rename constexpr function to const_expr for C23 compatibility

### DIFF
--- a/code/tools/lcc/src/c.h
+++ b/code/tools/lcc/src/c.h
@@ -645,7 +645,7 @@ extern int process(char *);
 extern int findfunc(char *, char *);
 extern int findcount(char *, int, int);
 
-extern Tree constexpr(int);
+extern Tree const_expr(int);
 extern int intexpr(int, int);
 extern Tree simplify(int, Type, Tree, Tree);
 extern int ispow2(unsigned long u);

--- a/code/tools/lcc/src/simp.c
+++ b/code/tools/lcc/src/simp.c
@@ -182,7 +182,7 @@ static int subi(long x, long y, long min, long max, int needconst) {
 static int subd(double x, double y, double min, double max, int needconst) {
 	return addd(x, -y, min, max, needconst);
 }
-Tree constexpr(int tok) {
+Tree const_expr(int tok) {
 	Tree p;
 
 	needconst++;
@@ -192,7 +192,7 @@ Tree constexpr(int tok) {
 }
 
 int intexpr(int tok, int n) {
-	Tree p = constexpr(tok);
+	Tree p = const_expr(tok);
 
 	needconst++;
 	if (p->op == CNST+I || p->op == CNST+U)

--- a/code/tools/lcc/src/stmt.c
+++ b/code/tools/lcc/src/stmt.c
@@ -119,7 +119,7 @@ void statement(int loop, Swtch swp, int lev) {
 		       		static char stop[] = { IF, ID, 0 };
 		       		Tree p;
 		       		t = gettok();
-		       		p = constexpr(0);
+		       		p = const_expr(0);
 		       		if (generic(p->op) == CNST && isint(p->type)) {
 		       			if (swp) {
 		       				needconst++;


### PR DESCRIPTION
The `constexpr` identifier became a reserved keyword in C23, causing compilation failures on systems with GCC 13+ that default to C23 (e.g., Fedora 42).

Fixes: https://github.com/suijingfeng/vkQuake3/issues/30

cc @suijingfeng 