### PR TITLE
Fix: Hunk_freeTempMemory: bad magic

### DIFF
--- a/code/renderer_vulkan/R_FindShader.c
+++ b/code/renderer_vulkan/R_FindShader.c
@@ -408,10 +408,8 @@ static void BuildSingleLargeBuffer(char* buffers[], const int nShaderFiles, cons
 }
 
 
-static void Shader_DoSimpleCheck(char* name, char* p)
+qboolean Shader_DoSimpleCheck(char* name, char* p)
 {
-    char* pBuf = p;
-
     R_BeginParseSession(name);
 
     while(1)
@@ -434,21 +432,18 @@ static void Shader_DoSimpleCheck(char* name, char* p)
                 ri.Printf(PRINT_WARNING, " (found \"%s\" on line %d)", token, R_GetCurrentParseLine());
             }
             ri.Printf(PRINT_WARNING, ".\n");
-            ri.FS_FreeFile(pBuf);
-            pBuf = NULL;
-            break;
+            return qfalse;
         }
 
         if(!SkipBracedSection(&p, 1))
         {
             ri.Printf(PRINT_WARNING, "WARNING: Ignoring shader file %s. Shader \"%s\" on line %d missing closing brace.\n",
                     name, shaderName, shaderLine);
-            ri.FS_FreeFile(pBuf);
-            pBuf = NULL;
-            break;
+            return qfalse;
         }
     }
 
+    return qtrue;
 }
 
 
@@ -548,7 +543,11 @@ void ScanAndLoadShaderFiles( void )
 		
 		// Do a simple check on the shader structure in that file
         // to make sure one bad shader file cannot fuck up all other shaders.
-	    Shader_DoSimpleCheck(filename, buffers[i]);
+	    if ( !Shader_DoSimpleCheck(filename, buffers[i]) ) {
+            ri.FS_FreeFile(buffers[i]);
+            buffers[i] = NULL;
+            continue;
+        }
 
 		if (buffers[i])
 			sum += summand;		


### PR DESCRIPTION
So, this is a possible fix to #5.

### Why it's crashing
If shader has an invalid syntax, `Shader_DoSimpleCheck` deallocates it. It also has a line, that was supposed to null that shader, but it was done wrong, so it does not. The address still lives and `BuildSingleLargeBuffer` attempts to interact with it, including second deallocation, which results in the issue mentioned earlier.

### Current state
It fixed issue in another fork of **vkQuake3** from @runlevel5 ( [the link](https://github.com/runlevel5/ioq3/tree/add-vulkan-renderer) ). After fixing `Fatal: VM_Free(cgame) on running vm`, it worked, and I was able to play a little bit in a windowed mode ( fullscreen was unstable ).

I haven't tried this repo yet, as I was constantly getting errors about `VK_ERROR_DEVICE_LOST`. I can't guarantee that the reason is not Wayland or my buggy nvidia drivers ( it has several issues with running vulkan applications, including [quake3e](https://github.com/ec-/quake3e) ), so would be glad if someone will try this fix.